### PR TITLE
Add an option for disabling automatic indent

### DIFF
--- a/lua/expadv/editor/ea_editor.lua
+++ b/lua/expadv/editor/ea_editor.lua
@@ -742,7 +742,7 @@ function PANEL:_OnKeyCodeTyped( code )
 					self:SetSelection( "\n" .. string_rep( "    ", math_floor( Count / 4 ) )  .. "    " )
 				end 
 			else 
-				if string_match( string_sub( Line, 1, self.Caret.y - 1 ), "{") then 
+				if string_match( string_sub( Line, 1, self.Caret.y - 1 ), "{") and cvars.Bool("expadv_editor_autoindent") then  
 					self:SetSelection( "\n" .. string_rep( "    ", math_floor( Count / 4 ) )  .. "    " )
 				else 
 					self:SetSelection( "\n" .. string_rep( "    ", math_floor( Count / 4 ) )  )
@@ -1752,5 +1752,7 @@ function PANEL:CloseCodeCompletionWindow( )
 end
 
 CreateClientConVar( "expadv_editor_codecompletion", 1, true )
+
+CreateClientConVar( "expadv_editor_autoindent", 1, true ) //Automatic Indentation
 
 vgui.Register( "EA_Editor", PANEL, "EditablePanel" ) 

--- a/lua/expadv/editor/ea_toolbar.lua
+++ b/lua/expadv/editor/ea_toolbar.lua
@@ -341,7 +341,7 @@ local function CreateOptions( )
 	
 	local Cvars = Panel:Add( "DHorizontalScroller" )
 	Cvars:Dock( TOP ) 
-	Cvars:DockMargin( 10, 5, 10, 0 )
+	Cvars:DockMargin( 10, 9, 10, 0 )
 	Cvars:AddPanel( kinect )
 	Cvars:AddPanel( Talk )
 	--Cvars:AddPanel( Console )
@@ -351,10 +351,17 @@ local function CreateOptions( )
 	CC:SetText( "Enable code completion " ) 
 	CC:SetConVar( "expadv_editor_codecompletion" )
 	CC:Dock( TOP ) 
-	CC:DockMargin( 10, 0, 10, 5 )
+	CC:DockMargin( 10, 0, 10, 9 )
 	CC:SizeToContents( )
 	
-	Panel:SetSize( 300, 315 ) 
+	local AInd = Panel:Add( "DCheckBoxLabel" ) 
+	AInd:SetText( "Enable auto indentation " ) 
+	AInd:SetConVar( "expadv_editor_autoindent" )
+	AInd:Dock( TOP ) 
+	AInd:DockMargin( 10, 0, 10, 9 )
+	AInd:SizeToContents( )
+	
+	Panel:SetSize( 300, 342 ) 
 	Panel:SetPos( cookie.GetNumber( "eaoptions_x", ScrW( ) / 2 - Panel:GetWide( ) / 2 ), cookie.GetNumber( "eaoptions_y", ScrH( ) / 2 - Panel:GetTall( ) / 2 ) ) 
 	
 	return Panel 


### PR DESCRIPTION
I noticed this feature was missing from the options, and I'd love to be able to do this. I don't see a drawback to adding this option, either. I also made the spacing on the checkboxes in the option panel a bit more uniform as well.