### PR TITLE
[**Pending merge**] #292, #293 united + other fixes (into `master`)

### DIFF
--- a/lua/expadv/components/android.lua
+++ b/lua/expadv/components/android.lua
@@ -152,29 +152,35 @@ function PANEL:Init()
 	self.btnClose:SetDrawBackground(false)
 
 	function self.btnAccept.DoClick()
-		for feature, _ in pairs(self.features) do
-			EXPADV.SetFeatureBlockedForEntity( self.entity, feature, false )
-			EXPADV.SetAcessToFeatureForEntity( self.entity, feature, true )
-		end
+		if IsValid( self.entity ) then
+			for feature, _ in pairs(self.features) do
+				EXPADV.SetFeatureBlockedForEntity( self.entity, feature, false )
+				EXPADV.SetAcessToFeatureForEntity( self.entity, feature, true )
+			end
 
-		self.entity.Context.Data.FeatureRequestMade = true
-		self.entity:CallEvent( "acceptedFeatures" )
+			self.entity.Context.Data.FeatureRequestMade = true
+			self.entity:CallEvent( "acceptedFeatures" )
+		end
 		self:Remove()
 	end
 
 	function self.btnBlock.DoClick()
-		for feature, _ in pairs(self.features) do
-			EXPADV.SetFeatureBlockedForEntity( self.entity, feature, true )
-			EXPADV.SetAcessToFeatureForEntity( self.entity, feature, false )
-		end
+		if IsValid( self.entity ) then
+			for feature, _ in pairs(self.features) do
+				EXPADV.SetFeatureBlockedForEntity( self.entity, feature, true )
+				EXPADV.SetAcessToFeatureForEntity( self.entity, feature, false )
+			end
 
-		self.entity.Context.Data.FeatureRequestMade = true
+			self.entity.Context.Data.FeatureRequestMade = true
+		end
 		self:Remove()
 	end
 
 	function self.btnClose.DoClick()
-		self.entity:CallEvent( "rejectedFeatures" )
-		//self.entity.Context.Data.FeatureRequestMade = true
+		if IsValid( self.entity ) then
+			self.entity:CallEvent( "rejectedFeatures" )
+			//self.entity.Context.Data.FeatureRequestMade = true
+		end
 		self:Remove()
 	end
 end

--- a/lua/expadv/components/array.lua
+++ b/lua/expadv/components/array.lua
@@ -2,7 +2,7 @@
 	@: Array Component
    ---	*/
 
-local Component = EXPADV.AddComponent( "arays" , true )
+local Component = EXPADV.AddComponent( "arrays" , true )
 
 Component.Author = "Rusketh"
 Component.Description = "Adds array objects."
@@ -23,14 +23,14 @@ Array:StringBuilder( function( A ) return string.format( "array<%s,%i>", EXPADV.
 	@: Wire Support
    ---	*/
 
-if WireLib then 
+if WireLib then
 	Array:WireIO( "STATICARRAY",
 		function(Value, Context) -- To Wire
 	        return table.Copy(Value)
 	    end, function(Value, context) -- From Wire
 	        return table.Copy(Value)
 	    end)
-	
+
 	if SERVER then
 		WireLib.DT.STATICARRAY = {
 			Zero = {__type = "n"}
@@ -83,7 +83,7 @@ Component:AddPreparedFunction("hasValue", "ar:vr", "b", [[
 		if @value 2[2] ~= @value 1.__type then
 			Context:Throw(@trace, "array", "variant not of array type, " .. @value 1.__type .. " expected got " .. EXPADV.TypeName(@value 2[2]))
 		end
-		
+
 		@value 2 = @value 2[1]
 	end
 
@@ -98,7 +98,7 @@ Component:AddPreparedFunction("hasValue", "ar:vr", "b", [[
 
 Component:AddFunctionHelper("hasValue", "ar:vr", "Checks if the given value is in the given array.")
 
-			
+
 
 /* --- --------------------------------------------------------------------------------
 	@: Unpack to vararg
@@ -106,7 +106,7 @@ Component:AddFunctionHelper("hasValue", "ar:vr", "Checks if the given value is i
 
 local function Unpack( Array, Index )
 	if Array[Index] == nil then return end
-	
+
 	if Array.__type == "_vr" then return Array[Index], Unpack( Array, Index + 1 ) end
 
 	return { Array[Index], Array.__type }, Unpack( Array, Index + 1 )
@@ -213,20 +213,20 @@ function Component:OnPostRegisterClass( Name, Class )
 
 	if !Class.Short == "_vr" then
 		Component:AddPreparedFunction("hasValue", "ar:" .. Class.Short, "b", [[
-			
+
 			if @value 1.__type ~= "]] .. Class.Short .. [[" then
 				Context:Throw(@trace, "array", "variant not of array type, "]] .. Class.Short .. [[" expected got " .. EXPADV.TypeName(@value 1.__type)) end
 			end
-			
+
 			@value 2 = @value 2[2]
 
 			@define found = false
 
 			for k, v in pairs(@value 1) do
 				if k == "__type" then continue end
-				
+
 				if @value 1.__type == "_vr" then
-					if v[2] ~= "]] .. Class.Short .. [[" then continue end 
+					if v[2] ~= "]] .. Class.Short .. [[" then continue end
 					v = v[1]
 				end
 
@@ -283,7 +283,7 @@ end
 
 		for Index, Value in pairs(Array) do
 			if Index ~= "__type" then
-				Result[Index] = EXPADV.ToString( Array.__type, Value ) 
+				Result[Index] = EXPADV.ToString( Array.__type, Value )
 			end
 		end
 
@@ -374,7 +374,7 @@ Component:AddFunctionHelper( "writeArray", "st:ar", "Appends an array to the str
 
 Component:AddVMFunction( "readArray", "st:", "ar", function( Context, Trace, Stream )
 	Stream.R = Stream.R + 1
-	
+
 	if !Stream.T[Stream.R] then
 		Context:Throw( Trace, "stream", "Failed to read array from stream, stream returned void." )
 	elseif Stream.T[Stream.R] ~= "_ar" then

--- a/lua/expadv/components/color.lua
+++ b/lua/expadv/components/color.lua
@@ -87,7 +87,7 @@ Component:AddInlineOperator( "string", "c", "s", "string.format( \"Color(%i, %i,
    --- */
 
 ColorObj:AddVMOperator( "=", "n,c", "", function( Context, Trace, MemRef, Value )
-	local Prev = Context.Memory[MemRef] or Color( 0, 0 , 0, 0 )
+	local Prev = Context.Memory[MemRef] or Color( 0, 0, 0, 0 )
 
 	Context.Memory[MemRef] = Value
 	Context.Delta[MemRef] = Color( Prev.r - Value.r, Prev.g - Value.g, Prev.b - Value.b, Prev.a - Value.a )

--- a/lua/expadv/components/color.lua
+++ b/lua/expadv/components/color.lua
@@ -103,6 +103,10 @@ ColorObj:AddInlineOperator( "$", "n", "c", "(Context.Delta[@value 1] or Color(0,
 Component:AddInlineFunction( "color", "n,n,n,n", "c", "Color(@value 1, @value 2, @value 3, @value 4)" )
 Component:AddFunctionHelper( "color", "n,n,n,n", "Creates a color object")
 EXPADV.AddFunctionAlias( "color", "n,n,n" )
+Component:AddInlineFunction( "color", "n,n", "c", "Color(@value 1, @value 1, @value 1, @value 2)" )
+Component:AddFunctionHelper( "color", "n,n", "Creates a color object, alias for color(number N, number N, number N, number M)")
+Component:AddInlineFunction( "color", "n", "c", "Color(@value 1, @value 1, @value 1)" )
+Component:AddFunctionHelper( "color", "n", "Creates a color object, alias for color(number N, number N, number N)")
 
 Component:AddPreparedFunction( "clone", "c:", "c", "Color(@value 1.r, @value 1.g, @value 1.b, @value 1.a)" )
 Component:AddFunctionHelper( "clone", "c:", "Returns a clone of the color." )

--- a/lua/expadv/components/number.lua
+++ b/lua/expadv/components/number.lua
@@ -394,8 +394,11 @@ Component:AddFunctionHelper( "log10", "n", "Returns the logarithm of (number) to
 Component:AddInlineFunction( "log", "n,n", "n", "(math.log(@value 1) / math.log(@value 2))" )
 Component:AddFunctionHelper( "log", "n,n", "Returns the logarithm of (number) to base (number)." )
 
-Component:AddInlineFunction("mix", "n,n,n", "n", "(@value 1 * @value 3 + @value 2 * (1 - @value 3))" )
+Component:AddInlineFunction( "mix", "n,n,n", "n", "(@value 1 * @value 3 + @value 2 * (1 - @value 3))" )
 Component:AddFunctionHelper( "mix", "n,n,n", "Returns a linear interpolation between three numbers." )
+
+Component:AddInlineFunction( "sign", "n", "n", "(( @value 1 > 0 ) and 1 or (( @value 1 < 0 ) and -1 or 0))" )
+Component:AddFunctionHelper( "sign", "n", "Returns sign of the number: -1, 0, 1." )
 
 /* --- --------------------------------------------------------------------------------
     @: Loop

--- a/lua/expadv/components/stream.lua
+++ b/lua/expadv/components/stream.lua
@@ -236,7 +236,7 @@ Component:AddVMFunction( "readColor", "st:", "c", function( Context, Trace, Stre
 
 	local Value = Stream.V[Stream.R]
 
-	return { Value.r, Value.g, Value.b, Value.a }
+	return { r = Value.r, g = Value.g, b = Value.b, a = Value.a }
 end )
 
 Component:AddVMFunction( "readStream", "st:", "st", function( Context, Trace, Stream )

--- a/lua/expadv/components/table.lua
+++ b/lua/expadv/components/table.lua
@@ -99,12 +99,16 @@ Component:AddInlineFunction( "type", "t:s", "s", "EXPADV.TypeName(@value 1.Types
 Component:AddInlineFunction( "type", "t:e", "s", "EXPADV.TypeName(@value 1.Types[@value 2])" )
 
 Component:AddPreparedFunction("connect", "t:t", "t", [[
-@value 1.Size = @value 1.Size + @value 2.Size
-@value 1.Count = @value 1.Count + @value 2.Count
-for I=1,#@value 1.Data,1 do
-	@value 1.Data[#@value 1.Data+1] = @value 2.Data[I]
-	@value 1.Types[#@value 1.Types+1] = @value 2.Types[I]
-end
+	for K, V in pairs( @value 2.Look ) do
+		if @value 1.Data[K] == nil then
+			MsgN( K )
+			@value 1.Size = @value 1.Size + 1
+		end
+		@value 1.Data[K] = @value 2.Data[K]
+		@value 1.Types[K] = @value 2.Types[K]
+		@value 1.Look[K] = K
+		if type( K ) == "number" then @value 1.Count = math.max( K, @value 1.Count ) end
+	end
 ]],"@value 1")
 
 Component:AddPreparedFunction("hasValue", "t:vr", "b", [[

--- a/lua/expadv/components/table.lua
+++ b/lua/expadv/components/table.lua
@@ -100,10 +100,7 @@ Component:AddInlineFunction( "type", "t:e", "s", "EXPADV.TypeName(@value 1.Types
 
 Component:AddPreparedFunction("connect", "t:t", "t", [[
 	for K, V in pairs( @value 2.Look ) do
-		if @value 1.Data[K] == nil then
-			MsgN( K )
-			@value 1.Size = @value 1.Size + 1
-		end
+		if @value 1.Data[K] == nil then @value 1.Size = @value 1.Size + 1 end
 		@value 1.Data[K] = @value 2.Data[K]
 		@value 1.Types[K] = @value 2.Types[K]
 		@value 1.Look[K] = K

--- a/lua/expadv/components/utility.lua
+++ b/lua/expadv/components/utility.lua
@@ -240,7 +240,7 @@ Component:AddInlineFunction( "time", "s", "n", "$tonumber( $os.date(\"!*t\")[ @v
 Component:AddFunctionHelper( "time", "s", "Returns the current time is unit S." )
 
 /* --- --------------------------------------------------------------------------------
-	@: Apparently we need unti convershion
+	@: Apparently we need unit convershion
    --- */
 local UnitSpeed = {
 	["u/s"] = 1 / 0.75,

--- a/lua/expadv/components/wire.lua
+++ b/lua/expadv/components/wire.lua
@@ -90,14 +90,13 @@ end
    --- */
 
 local function GetOwner( Entity )
-	if !IsValid( Entity ) return nil end
+	if !IsValid( Entity ) then return nil end
 	local Owner
 	if Entity.IsWire then Owner = WireLib.GetOwner( Entity )
 	else Owner = EXPADV.GetOwner( Entity ) end
 	return Owner
 end
 local function PPCheck( Context, Entity )
-	if !IsValid( Entity ) return false end
 	if IsValid( Context.entity ) and Context.entity.Scripted then return true end
 	if !IsValid( Context.player ) then return false end
 

--- a/lua/expadv/components/wire.lua
+++ b/lua/expadv/components/wire.lua
@@ -6,7 +6,7 @@ if !WireLib then return end
 
 local Component = EXPADV.AddComponent( "wire" , true )
 
-Component.Author = "Rusketh"
+Component.Author = "Rusketh, VINTproYKT"
 Component.Description = "Adds basic wiremod and wirelink support."
 
 EXPADV.ServerOperators( )
@@ -88,6 +88,22 @@ end
 /* --- --------------------------------------------------------------------------------
 	@: Functions
    --- */
+
+local function GetOwner( Entity )
+	if !IsValid( Entity ) return nil end
+	local Owner
+	if Entity.IsWire then Owner = WireLib.GetOwner( Entity )
+	else Owner = EXPADV.GetOwner( Entity ) end
+	return Owner
+end
+local function PPCheck( Context, Entity )
+	if !IsValid( Entity ) return false end
+	if IsValid( Context.entity ) and Context.entity.Scripted then return true end
+	if !IsValid( Context.player ) then return false end
+
+	local Owner = GetOwner( Entity )
+	return Owner == Context.player or EXPADV.IsFriend( Context.player, Owner )
+end
 
 Component:AddVMFunction( "hasInput", "wl:s", "b", function( Context, Trace, WireLink, Index )
 		return IsValid( WireLink ) and WireLink.Inputs and WireLink.Inputs[Index]
@@ -198,7 +214,7 @@ end
 Component:AddVMFunction( "writeStringZero", "wl:n,s", "n", WriteStringZero )
 Component:AddVMFunction( "readStringZero", "wl:n", "s", ReadStringZero )
 
-function linkWireIO( Dst, DstId, Src, SrcId ) -- Baked: unified global function that can be then used in the whole code
+function linkWireIO( Dst, DstId, Src, SrcId )
 	/* Modified version:
 		local function Wire_Link - as spotted in lua/wire/server/wirelib.lua */
 
@@ -237,7 +253,7 @@ function EXPADV.linkWireIO( Context, Trace, Dst, DstId, Src, SrcId )
 	if !IsValid(Src) or !WireLib.HasPorts(Src) or !Src.Outputs then Context.Throw( Trace, "linkWireIO", tostring( Src ) .." has no wire outputs" ) end
 	if !Dst.Inputs[DstId] then Context.Throw( Trace, "linkWireIO", tostring( Dst ) .." has no `".. DstId .."` input" ) end
 	if !Src.Outputs[SrcId] then Context.Throw( Trace, "linkWireIO", tostring( Src ) .." has no `".. SrcId .."` output" ) end
-	if !EXPADV.PPCheck( Context, Dst ) || !EXPADV.PPCheck( Context, Src ) then return end
+	if !PPCheck( Context, Dst ) || !PPCheck( Context, Src ) then return end
 	linkWireIO( Dst, DstId, Src, SrcId )
 	return true
 end

--- a/lua/expadv/components/wire.lua
+++ b/lua/expadv/components/wire.lua
@@ -255,6 +255,7 @@ Component:AddFunctionHelper( "outputType", "wl:s", "Returns the wiretype of an o
 Component:AddFunctionHelper( "hasInput", "wl:s", "Returns true if the linked component has an input of the specified name." )
 Component:AddFunctionHelper( "isHiSpeed", "wl:", "Returns true if the wirelinked object supports the HiSpeed interface. See wiremod wiki for more information." )
 Component:AddFunctionHelper( "inputType", "wl:s", "Returns the wiretype of an input on the linked component." )
+Component:AddFunctionHelper( "linkWireIO", "e,s,e,s", "Wires input of first `entity` to output of second. 1st `string` - input, 2nd - output name. Returns true on success." )
 
 /* --- --------------------------------------------------------------------------------
 	@: Events

--- a/lua/expadv/cppi.lua
+++ b/lua/expadv/cppi.lua
@@ -62,9 +62,8 @@ local ObjectOwners, Friends = { }, { }
 function EXPADV.GetOwner( Entity )
 	if !IsValid( Entity ) then return end
 	
-	local Owner -- For some reason ObjectOwners is not filling with Wire entities, ...
-	if Entity.IsWire then Owner = WireLib.GetOwner( Entity ) -- so we use WireLib function
-	elseif Entity.ExpAdv then Owner = Entity.player
+	local Owner
+	if Entity.ExpAdv then Owner = Entity.player
 	elseif ObjectOwners[Entity] then Owner = player.GetByUniqueID( ObjectOwners[Entity] ) end
 	
 	return Owner

--- a/lua/expadv/cppi.lua
+++ b/lua/expadv/cppi.lua
@@ -64,6 +64,7 @@ function EXPADV.GetOwner( Entity )
 	
 	local Owner -- For some reason ObjectOwners is not filling with Wire entities, ...
 	if Entity.IsWire then Owner = WireLib.GetOwner( Entity ) -- so we use WireLib function
+	elseif Entity.ExpAdv then Owner = Entity.player
 	elseif ObjectOwners[Entity] then Owner = player.GetByUniqueID( ObjectOwners[Entity] ) end
 	
 	return Owner

--- a/lua/expadv/cppi.lua
+++ b/lua/expadv/cppi.lua
@@ -60,11 +60,12 @@ local UIDCach = { } -- Because UniqueID is slow and isn't cached, Fix it *KILLBU
 local ObjectOwners, Friends = { }, { }
 
 function EXPADV.GetOwner( Entity )
-	if !IsValid( Entity ) or !ObjectOwners[Entity] then return end
-
-	local Owner = player.GetByUniqueID( ObjectOwners[Entity] )
-	if !IsValid( Owner ) then return end
-
+	if !IsValid( Entity ) then return end
+	
+	local Owner -- For some reason ObjectOwners is not filling with Wire entities, ...
+	if Entity.IsWire then Owner = WireLib.GetOwner( Entity ) -- so we use WireLib function
+	elseif ObjectOwners[Entity] then Owner = player.GetByUniqueID( ObjectOwners[Entity] ) end
+	
 	return Owner
 end
 

--- a/lua/expadv/editor/ea_editor.lua
+++ b/lua/expadv/editor/ea_editor.lua
@@ -889,6 +889,15 @@ function PANEL:_OnKeyCodeTyped( code )
 					break 
 				end 
 			end
+		elseif code == KEY_RBRACKET then
+			if shift then
+				local RCBOut = GetConVar("expadv_rcb_outdent")
+				RCBOut = RCBOut && RCBOut:GetBool()
+				if RCBOut then
+					local Caret = self.Caret:Clone( )
+					if string.Replace( self.Rows[Caret.x], " ", "" ) == "" then code = KEY_TAB end
+				end
+			end
 		end 
 	end
 	
@@ -1751,6 +1760,7 @@ function PANEL:CloseCodeCompletionWindow( )
 	end
 end
 
+CreateClientConVar( "expadv_rcb_outdent", 1, true )
 CreateClientConVar( "expadv_editor_codecompletion", 1, true )
 
 vgui.Register( "EA_Editor", PANEL, "EditablePanel" ) 

--- a/lua/expadv/editor/ea_editorpanel.lua
+++ b/lua/expadv/editor/ea_editorpanel.lua
@@ -35,8 +35,8 @@ function PANEL:Init( )
 	self:SetMinWidth( 600 )
 	self:SetMinHeight( 400 )
 	self:SetText( "Expression Advanced Editor" )
-	self:SetSize( cookie.GetNumber( "eaeditor_w", math.min( 1000, ScrW( ) * 0.8 ) ), cookie.GetNumber( "eaeditor_h", math.min( 800, ScrH( ) * 0.8 ) ) )
-	self:SetPos( cookie.GetNumber( "eaeditor_x", ScrW( ) / 2 - self:GetWide( ) / 2 ), cookie.GetNumber( "eaeditor_y", ScrH( ) / 2 - self:GetTall( ) / 2 ) )
+	self:SetSize( EXPADV.ReadUserSetting( "editor_w", math.min( 1000, ScrW( ) * 0.8 ) ), EXPADV.ReadUserSetting( "editor_h", math.min( 800, ScrH( ) * 0.8 ) ) )
+	self:SetPos( math.Clamp( EXPADV.ReadUserSetting( "editor_x", ScrW( ) / 2 - self:GetWide( ) / 2 ), 0, ScrW( ) - 20 ), EXPADV.ReadUserSetting( "editor_y", ScrH( ) / 2 - self:GetTall( ) / 2 ) )
 
 	self.ExitSave = self:Add( "EA_ImageButton" )
 	self.ExitSave:SetMaterial(Material("fugue/disk.png"))
@@ -142,6 +142,7 @@ function PANEL:Init( )
 		local Code = self:GetCode( )
 		if Code == "" then return end
 		file.Write( "expadv2/_shutdown_.txt", Code )
+		self:SaveCoords( )
 	end )
 	
 	file.CreateDir( "expadv2" )
@@ -150,6 +151,14 @@ function PANEL:Init( )
 	self.__nMicAlpha = 0
 
 	timer.Create( "expadv.editor.validator", 1, 0, function( ) self:ResumeValidator( ) end )
+end
+
+function PANEL:SaveCoords( )
+	EXPADV.CL_Settings.settings["editor_x"] = self.x
+	EXPADV.CL_Settings.settings["editor_y"] = self.y
+	EXPADV.CL_Settings.settings["editor_w"] = self:GetWide()
+	EXPADV.CL_Settings.settings["editor_h"] = self:GetTall()
+	EXPADV.SaveConfig( )
 end
 
 function PANEL:SetCode( Code, Tab )
@@ -554,10 +563,7 @@ function PANEL:Close( )
 	self:SaveTabs( )
 	self:AutoSave( )
 	
-	cookie.Set( "eaeditor_x", self.x )
-	cookie.Set( "eaeditor_y", self.y )
-	cookie.Set( "eaeditor_w", self:GetWide( ) )
-	cookie.Set( "eaeditor_h", self:GetTall( ) )
+	self:SaveCoords( )
 	
 	self:SetVisible( false )
 	if ValidPanel( EXPADV.Helper ) and EXPADV.Helper:IsVisible( ) then

--- a/lua/expadv/editor/ea_frame.lua
+++ b/lua/expadv/editor/ea_frame.lua
@@ -98,6 +98,10 @@ function PANEL:SetTall( n, bool )
 end
 
 function PANEL:Think( )
+	local x, y = self:GetPos()
+	if y < 0 then self:SetPos( x, 0 )
+	elseif y > ScrH() - 25 then self:SetPos( x, ScrH() - 25 ) end
+	
 	if self.IsMoving then
 		self:SetCursor( "blank" )
 		return

--- a/lua/expadv/editor/ea_search.lua
+++ b/lua/expadv/editor/ea_search.lua
@@ -205,12 +205,12 @@ end
 function PANEL:Think( )
 	local Tall = self.Expanded and 75 or 50
 
-	self.T = self.T + math.Clamp( Tall - self.T, -2, 2 )
+	self.T = self.T + math.Clamp( Tall - self.T, -10, 10 )
 	self:SetTall( self.T )
 
 	local Dest = self.Extended and 5 or -(self:GetTall() + 5)
 	
-	self.Y = self.Y + math.Clamp( Dest - self.Y, -2, 2 )
+	self.Y = self.Y + math.Clamp( Dest - self.Y, -10, 10 )
 	self:SetPos( self:GetPos( ), self.Y )
 end
 

--- a/lua/expadv/editor/ea_toolbar.lua
+++ b/lua/expadv/editor/ea_toolbar.lua
@@ -338,7 +338,12 @@ local function CreateOptions( )
 	--KeyEvents:SetText( "Share Keys? " ) 
 	--KeyEvents:SetConVar( "lemon_share_keys" ) 
 	--KeyEvents:SizeToContents( )
-	
+
+	local RCBOut = vgui.Create( "DCheckBoxLabel" ) 
+	RCBOut:SetText( "Bracket auto-outdentation " ) 
+	RCBOut:SetConVar( "expadv_rcb_outdent" )
+	RCBOut:SizeToContents( )
+
 	local Cvars = Panel:Add( "DHorizontalScroller" )
 	Cvars:Dock( TOP ) 
 	Cvars:DockMargin( 10, 5, 10, 0 )
@@ -346,6 +351,7 @@ local function CreateOptions( )
 	Cvars:AddPanel( Talk )
 	--Cvars:AddPanel( Console )
 	--Cvars:AddPanel( KeyEvents )
+	Cvars:AddPanel( RCBOut )
 
 	local CC = Panel:Add( "DCheckBoxLabel" ) 
 	CC:SetText( "Enable code completion " ) 

--- a/lua/expadv/editor/manual.lua
+++ b/lua/expadv/editor/manual.lua
@@ -59,6 +59,17 @@ local PANEL = { }
 	function PANEL:Search( Query )
 		self.Contents:Clear( )
 
+		local Desc_Col = 0
+		for i = 6, 1, -1 do
+			local Column = self.Contents.Columns[i]
+			if IsValid( Column ) then
+				if Column.Header:GetText() == "Description" then
+					Desc_Col = i
+					break
+				end
+			end
+		end
+
 		local TotalResults = 0
 
 		for I = 1, #self.Lines do
@@ -78,7 +89,11 @@ local PANEL = { }
 			if !AddLine then continue end
 
 			TotalResults = TotalResults + 1
-			self.Contents:AddLine( Line[1], Line[2], Line[3], Line[4], Line[5], Line[6] )
+			local Row = self.Contents:AddLine( Line[1], Line[2], Line[3], Line[4], Line[5], Line[6] )
+			
+			if Desc_Col > 1 then
+				Row:SetTooltip( ( Line[Desc_Col - 1] or "" ) .."\n\n".. ( Line[Desc_Col] or "No description" ) )
+			end
 		end
 
 		if TotalResults == 0 then
@@ -88,6 +103,8 @@ local PANEL = { }
 		else
 			self.Label:SetText( self.LabelText )
 		end
+
+		self.Contents:SortByColumn( 3 ) -- Universal almost for all EA_HelpList blocks
 	end
 
 vgui.Register( "EA_HelpList", PANEL, "DPanel" )
@@ -101,7 +118,7 @@ function PANEL:MakeInfoSheet( )
 	self.Sheet_Info = self:Add( "EA_HelpList" )
 	self.Sheet_Info:SetLabel( "Information" )
 
-	self.Sheet_Info:AddColumn( "", 60 )
+	self.Sheet_Info:AddColumn( "", 100 )
 	self.Sheet_Info:AddColumn( "" )
 end
 
@@ -132,7 +149,7 @@ function PANEL:MakeOperatorSheet( )
 	self.Sheet_Operator:AddColumn( "Avalibility", 60 )
 	self.Sheet_Operator:AddColumn( "Operator",  70 )
 	self.Sheet_Operator:AddColumn( "Return",  60 )
-	self.Sheet_Operator:AddColumn( "Example" )
+	self.Sheet_Operator:AddColumn( "Example", 300 )
 	self.Sheet_Operator:AddColumn( "Description" )
 end
 
@@ -148,7 +165,7 @@ function PANEL:MakeFunctionSheet( )
 
 	self.Sheet_Function:AddColumn( "Avalibility", 60 )
 	self.Sheet_Function:AddColumn( "Return", 60 )
-	self.Sheet_Function:AddColumn( "Function" )
+	self.Sheet_Function:AddColumn( "Function", 300 )
 	self.Sheet_Function:AddColumn( "Description" )
 end
 
@@ -164,7 +181,7 @@ function PANEL:MakeMethodSheet( )
 
 	self.Sheet_Method:AddColumn( "Avalibility", 60 )
 	self.Sheet_Method:AddColumn( "Return", 60 )
-	self.Sheet_Method:AddColumn( "Method" )
+	self.Sheet_Method:AddColumn( "Method", 300 )
 	self.Sheet_Method:AddColumn( "Description" )
 end
 
@@ -180,7 +197,7 @@ function PANEL:MakeEventSheet( )
 
 	self.Sheet_Event:AddColumn( "Avalibility", 60 )
 	self.Sheet_Event:AddColumn( "Return", 60 )
-	self.Sheet_Event:AddColumn( "Event" )
+	self.Sheet_Event:AddColumn( "Event", 300 )
 	self.Sheet_Event:AddColumn( "Description" )
 end
 
@@ -373,9 +390,9 @@ function EXPADV.Editor.OpenHelper( )
 
 		TabSheet:AddSheet( "Components", ComponentTabSheet, nil, true, true, "Components & Classes" )
 		TabSheet:AddSheet( "Browser", BrowserCanvas, nil, true, true, "Browse" )
-		TabSheet:AddSheet( "Wiki and Syntax", WikiTabSheet, nil, true, true, "Syntax documentation." )
-		TabSheet:AddSheet( "Examples", ExamplesTabSheet, nil, true, true, "Example Codes." )
-		TabSheet:AddSheet( "Tutorial", GuideTabSheet, nil, true, true, "EXPADV2 For Dummies." )
+		TabSheet:AddSheet( "Wiki and Syntax", WikiTabSheet, nil, true, true, "Syntax documentation" )
+		TabSheet:AddSheet( "Examples", ExamplesTabSheet, nil, true, true, "Example Codes" )
+		TabSheet:AddSheet( "Tutorial", GuideTabSheet, nil, true, true, "EXPADV2 For Dummies" )
 
 	-- COMPONENTS & CLASSES:
 
@@ -500,11 +517,17 @@ function EXPADV.Editor.OpenHelper( )
 			Frame:SetActiveComponentPage( "core" )
 		end
 
-		for _, Component in pairs( EXPADV.Components ) do
+		local SortedComp = {}
+		for _, Comp in pairs( EXPADV.Components ) do
+			table.insert( SortedComp, Comp )
+		end
+		table.SortByMember( SortedComp, "Name", true )
+
+		for _, Component in ipairs( SortedComp ) do
 			local Page = Frame:GetComponentPanel( Component.Name )
 
 			Page:GetInfoSheet( ):AddLine( "Component", Component.Name )
-			Page:GetInfoSheet( ):AddLine( "Author", Component.Author or "Unkown" ) 
+			Page:GetInfoSheet( ):AddLine( "Author", Component.Author or "Unknown" ) 
 			Page:GetInfoSheet( ):AddLine( "Status", Component.Enabled and "Enabled" or "Disabled" )
 			Page:GetInfoSheet( ):AddLine( "Description", Component.Description or "N/A" )
 
@@ -603,16 +626,28 @@ function EXPADV.Editor.OpenHelper( )
 		local RootClassNode = NodeList:AddNode( "Classes" )
 		RootClassNode:SetIcon( "fugue/rocket-fly.png" )
 
+		-- Preparation hack for SortedPairs
+		local LongToShort = {}
+		local ClNew = {}
 		for Short, Panel in pairs( ClassPanels ) do
+			local Unit = EXPADV.GetClass( Short )
+			local Long
+			if Unit ~= nil then Long = Unit.Name
+			else Long = "unknown:".. Short end
+			LongToShort[Long] = Short
+			ClNew[Long] = Panel
+		end
 
-			local Class = EXPADV.GetClass(Short)
+		for Long, Panel in SortedPairs( ClNew ) do
+			local Short = LongToShort[Long]
+			local Class = EXPADV.GetClass( Short )
 			local Page = Frame:GetClassPanel( Short )
 
 			if !Class or !Page then
 				continue
 			end
 
-			Page:GetInfoSheet( ):AddLine( "Class", Class.Name )
+			Page:GetInfoSheet( ):AddLine( "Class", Long )
 			Page:GetInfoSheet( ):AddLine( "Extends", Class.DerivedClass and Class.DerivedClass.Name or "generic" ) 
 			Page:GetInfoSheet( ):AddLine( "Component", Class.Component and Class.Component.Name or "Core" )
 			Page:GetInfoSheet( ):AddLine( "Avalibility", GetAvalibility( Class ) )
@@ -624,14 +659,14 @@ function EXPADV.Editor.OpenHelper( )
 				ComponentNode.ClassNode:SetIcon( "fugue/rocket-fly.png" )
 			end
 
-			local Node = ComponentNode.ClassNode:AddNode( Class.Name )
+			local Node = ComponentNode.ClassNode:AddNode( Long )
 			Node:SetIcon( "fugue/block.png" )
 
 			function Node:DoClick( )
 				Frame:SetActiveClassPage( Short )
 			end
 
-			local Node = RootClassNode:AddNode( Class.Name )
+			local Node = RootClassNode:AddNode( Long )
 			Node:SetIcon( "fugue/block.png" )
 
 			function Node:DoClick( )

--- a/lua/expadv/net.lua
+++ b/lua/expadv/net.lua
@@ -129,14 +129,14 @@ elseif CLIENT then
 
 			if script and script ~= "" then
 				local editor = EXPADV.Editor.GetInstance()
-				local tab = editor.GateTabs[ExpAdv]
+				local tab = editor.GateTabs[entity]
 
 				local name = "generic"
 				if entity.GetGateName then
 					name = entity:GetGateName()
 				end
 
-				if !tab then
+				if !IsValid( tab ) then
 					editor:NewTab(script, nil, name)
 					tab = editor.TabHolder:GetActiveTab()
 					tab.Entity = entity


### PR DESCRIPTION
All references (`@...`) are pointing to recent history commits.
- [x] Tests made, all works.
- [x] Compared with pure `master`, no conflicts.

## Done
I think these 8 issues (#288, #283, #277, #264, #262, #253, #250, #240) now can be closed to not mess with unsolved ones.

## Commits overview
* @da52e3a: `lua/expadv/editor/manual.lua`
 * @153d911 - More space for descriptions in manual
 * @d07c140 - Ultra-minor
 * @ca44696 - Sort every EA_HelpList by 3rd column. Looks pretty now
 * @119e236 - Alphabetical components tree
 * @12fca7e - Made classes menu sorted
 * @3ef874f - Put EA_HelpList descriptions into tooltip
* @7cc03d3: `lua/expadv/editor/ea_search.lua`
 * @ee15c8e - Faster search panel opening/closing
* @a11a446: lua/expadv/cppi.lua
 * @0e5187d - CPPI: GetOwner of Wire entities
* @f43868f: `lua/expadv/editor/ea_frame.lua`
 * @e97b922 - Force all frames to stay down with their roofs
 * @b9f3001 - Make frames not going out a vertical of the screen
* @45cf5fa: `lua/expadv/components/wire.lua`
 * @ccef853 - Added `linkWireIO` function into `wire` component
 * @012473b - linkWireIO - Check passage of prop protection check
 * @718d037 - Made linkWireIO global function in Lua environment + separation of VMFunctions ~~(depends on 5th arguments)~~
 * @5b49e87 - Unscoped EXPADV.linkWireIO
 * @d3edcdd - Removed Path from linkWireIO, cause it actually does nothing meaningful
* @ba19366: lua/expadv/editor/ea_editorpanel.lua
 * @b49901c - Added ability to share position and sizes of editor panel between **game** sessions. Saves them on close and shutdown.
* @365f09c: *`miscellaneous`*
 * @073ea8a - "r" - journey back
 * @1867241 - Grammar
* @efaa45e: `lua/expadv/components/number.lua`
 * @a159c2d - Added `sign`. Solves #288
* @cff12c3: `lua/expadv/editor/ea_editor.lua`
 * @8514e60 - Automatic outdent of right curly bracket in editor. Solves #283
 * @6b00c21 - Option added: `Bracket auto-outdentation`
* @3f5cead: `lua/expadv/components/wire.lua`
 * @3f5cead683eea8620e79bbe4117fdc33ac1dbbdf - Little mistake after uniting two pull requests
* @8ef33d0: `lua/expadv/components/android.lua`
 * @8ef33d0e3533327fd4a6f84449fc88369dae9dfc - Solves #277. Check that gate exists in `android` on every `onClick`, so it will not throw override error that prevents dialog from closing.
* @87c48e6: `lua/expadv/components/table.lua`
 * @87c48e60a8d8f6939bf31a69f32eb8c42b47fe15 - table.connect(table) fixed. Solves #264
* @694ae89: `lua/expadv/net.lua`
 * @694ae8974cbfec031c2fe70f8ed30c04e88da88d - Actually link entity to tab. Solves #262
* @725a723: `lua/expadv/components/color.lua`
 * @725a723ee26093560c90aa6da4ff4acf135cd30e - Color aliases color(N,M) and color(N)
* @22f059f: `lua/expadv/cppi.lua`
 * @22f059f2ddde00d1c88a76eed2eb1af91530b690 - Added get condition for ExpAdv's owner. Fixes #250
* @5cbc080: *`miscellaneous`*
 * @5cbc080be6968f48639c562da1e3178bbd5d726b - Netstream `readColor` fixed. Solves #240 
* @3ad92ab: `lua/expadv/components/table.lua`
 * @3ad92abbbc2a6904413b9fc32ab65bf3e71e8bd2 - Removed MsgN from `table`
* @95a7c9d: *`miscellaneous`*
 * @95a7c9dd8c9634ca0d5bb99b219d9282d88a0ef4 - Separated `wire` GetOwner and PPCheck
* @b9220bf: `lua/expadv/components/wire.lua`
 * @b9220bf0fe257ee75a23937af7538c3360a04d75 - Liquidated unnecessary `IsValid`