### PR TITLE
Request to unblock using IP in playURL()

### DIFF
--- a/lua/expadv/components/sound.lua
+++ b/lua/expadv/components/sound.lua
@@ -260,7 +260,6 @@ EXPADV.URL_SOUNDS = EXPADV.URL_SOUNDS or {}
 Component:AddVMFunction( "playURL", "s,s,d,d", "", 
 	function( Context, Trace, URL, Flags, Sucess, Fail )
 		if !IsValid(Context.entity) or !EXPADV.CanAccessFeature(Context.entity, "PlayURL") then return end
-		if string.find(URL, "%d%d?%d?%.%d%d?%d?%.%d%d?%d?%.%d%d?%d?") then return end
 
 		sound.PlayURL( URL, Flags,
 			function( Channel, Er_ID, Er_Name ) 


### PR DESCRIPTION
Why blocking ip in urlplay? if string.find(URL, "%d%d?%d?%.%d%d?%d?%.%d%d?%d?%.%d%d?%d?") then return end
Becous of this i cant use hosted sounds from pc with is much easier.